### PR TITLE
Fixade typo: /wp-login/ -> /wp-login.php

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 
 					<p>För att ta reda på vilka CMS respektive partiwebbsajt använde sig av så gick vi manuellt igenom sajterna. Med ögonen, webbläsaren och terminalen.</p>
 					<p>
-						Vi har tittat efter allt från <a href="https://en.wikipedia.org/wiki/Meta_element">meta-taggar</a> i form av <code>GENERATOR</code> till vanliga sökvägar för login till cmsen, t.ex. <code>/wp-login/</code>för WordPress och <code>/Util/Login.aspx</code> för EpiServer.
+						Vi har tittat efter allt från <a href="https://en.wikipedia.org/wiki/Meta_element">meta-taggar</a> i form av <code>GENERATOR</code> till vanliga sökvägar för login till cmsen, t.ex. <code>/wp-login.php</code>för WordPress och <code>/Util/Login.aspx</code> för EpiServer.
 					</p>
 					<p>Med hjälp av verktyget <a href="https://github.com/jkbrzt/httpie">httpie</a> har vi tittat på de <a href="https://en.wikipedia.org/wiki/List_of_HTTP_header_fields">&#8220;headers&#8221;</a> som webbservrarna skickar.
 					Vi kan bland dessa headers ofta ta reda på vilken server som används och om cookie sätts av webbplatsen.


### PR DESCRIPTION
/wp-login/ som mapp finns ej,.
